### PR TITLE
fix(prometheus-paperless-ngx-exporter): Fix wrong Interface Port

### DIFF
--- a/json/prometheus-paperless-ngx-exporter.json
+++ b/json/prometheus-paperless-ngx-exporter.json
@@ -8,7 +8,7 @@
     "type": "ct",
     "updateable": true,
     "privileged": false,
-    "interface_port": 3000,
+    "interface_port": 8081,
     "documentation": null,
     "website": "https://github.com/hansmi/prometheus-paperless-exporter",
     "logo": "https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/main/resources/logo/web/svg/square.svg",


### PR DESCRIPTION
## ✍️ Description

Fixes the reported issue where the Prometheus Paperless NGX Exporter LXC was documented with the wrong port number (3000 instead of 8081). This PR updates the documentation to reflect the correct port `8081` on which the exporter is running.

## 🔗 Related PR / Discussion / Issue

Link: #2808

## ✅ Prerequisites

Before this PR can be reviewed, the following must be completed:

- [x] **Self-review performed** – Code follows established patterns and conventions. (In this case, documentation)
- [x] **Testing performed** – Changes have been thoroughly tested and verified. (Verified the correct port)

## 🛠️ Type of Change

Select all that apply:

- [x] 🐞 **Bug fix** – Resolves an issue without breaking functionality.

## 📋 Additional Information (optional)

The website and potentially other documentation sources incorrectly state the port for the Prometheus Paperless NGX Exporter LXC as 3000.  The actual port the service runs on is 8081. This change corrects the discrepancy.
